### PR TITLE
Contextual parsing for Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Contextual parsing has experimental support for the following languages:
 - python
 - r
 - ruby
+- rust
 - scss
 - swift
 - typescript

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -129,6 +129,7 @@ export default class Settings {
             case "less":
             case "scss":
             case "dart":
+            case "rust":
                 {
                     this.scopes.push(doubleForwardslashComment);
                     this.scopes.push(slashCommentBlock);


### PR DESCRIPTION
My 2c (two lines exactly) to this project.

This pull request just adds Rust to the same case as all C-like languages.