### PR TITLE
Added support for Stylable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Contextual parsing has experimental support for the following languages:
 - rust
 - scss
 - sql
+- stylable
 - swift
 - typescript
 ```

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -205,6 +205,7 @@ export default class Settings {
                 this.scopes.push(singleQuoteBlock);
                 break;
             }
+            case "stylable":
             case "css": {
                 this.scopes.push(slashCommentBlock);
                 this.scopes.push(doubleQuoteBlock);


### PR DESCRIPTION
[Stylable](https://www.stylable.io) is a css pre-processor that uses the suffix `.st.css`. 
Our language server takes over `.st.css` files, so their language ID is 'stylable' and not 'css'.

By adding it to the same case as CSS (in your settings) the two extensions can play together nicely.
Hope you'll accept the PR.