### PR TITLE
Adding support for Visual Studio Live Share

### DIFF
--- a/src/documentDecorationManager.ts
+++ b/src/documentDecorationManager.ts
@@ -90,6 +90,6 @@ export default class DocumentDecorationManager {
             return false;
         }
 
-        return document.uri.scheme === "file" || document.uri.scheme === "untitled";
+        return document.uri.scheme === "file" || document.uri.scheme === "untitled" || document.uri.scheme === "vsls";
     }
 }


### PR DESCRIPTION
This PR simply adds support for [Visual Studio Live Share](http://aka.ms/vsls), which will allow developers who have installed this extension, to continue viewing their beautiful brackets while collaborating on someone else's project. On the guest's side, during a Live Share session, files use the `vsls` scheme, which prevents this extension from colorizing any brackets, despite the fact that it would otherwise work.

The following is the experience after this PR (which is sooo pretty 💯). Before this PR, the VS Code instance on the left (which is a "guest" who has joined a VS Live Share session), would have their brackets rendered using the same color, even though they have this extension installed.

<img width="1256" alt="screen shot 2018-02-21 at 2 50 37 pm" src="https://user-images.githubusercontent.com/116461/36510066-a8213404-1716-11e8-966a-eaf81bf7f1d3.png">

**FYI**: I chose to simple add the additional scheme condition, as opposed to refactoring the logic to be more flexible, but I'm open to additional changes.

// CC @CoenraadS 