### PR TITLE
Fix slash-asterisk comments problem in OpenSCAD

### DIFF
--- a/src/documentDecorationManager.ts
+++ b/src/documentDecorationManager.ts
@@ -107,7 +107,7 @@ export default class DocumentDecorationManager {
             case "javascriptreact": return "jsx";
             case "typescriptreact": return "tsx";
             case "jsonc": return "json5";
-            case "scad": return "json";
+            case "scad": return "swift"; // workaround for unsupported language in Prism
             case "vb": return "vbnet";
             default: return languageID;
         }


### PR DESCRIPTION
The JSON workaround has problems with /* comments. Switching to Swift everything shows as expected :-)