### PR TITLE
added backgroundColor: {color-alpha} feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
                     "description": "Should different brackets share a color group (Consecutive), or use their own color group (Independent)",
                     "scope": "resource"
                 },
+                "bracketPairColorizer.highlightBracketBackgroundAlpha": {
+                    "type": "number",
+                    "default": 0.55,
+                    "description": "Decimal number from 0 to 1 for the alpha channel on the highlighted bracket background. Only works if \"backgroundColor: {color-alpha};\" is set in bracketPairColorizer.activeScopeCSS and bracketPairColorizer.highlightActiveScope is set to true.",
+                    "scope": "resource"
+                },
                 "bracketPairColorizer.highlightActiveScope": {
                     "type": "boolean",
                     "default": false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,7 @@ export default class Settings {
     public readonly prismLanguageID: string;
     public readonly regexNonExact: RegExp;
     public readonly timeOutLength: number;
+    public readonly highlightBracketBackgroundAlpha: number;
     public readonly highlightActiveScope: boolean;
     public readonly showVerticalScopeLine: boolean;
     public readonly showHorizontalScopeLine: boolean;
@@ -68,6 +69,12 @@ export default class Settings {
 
         if (typeof this.highlightActiveScope !== "boolean") {
             throw new Error("alwaysHighlightActiveScope is not a boolean");
+        }
+
+        this.highlightBracketBackgroundAlpha = configuration.get("highlightBracketBackgroundAlpha") as number;
+
+        if (typeof this.highlightBracketBackgroundAlpha !== "number") {
+            throw new Error("highlightBracketBackgroundAlpha is not a number");
         }
 
         this.showVerticalScopeLine = configuration.get("showVerticalScopeLine") as boolean;
@@ -236,12 +243,18 @@ export default class Settings {
     }
 
     public createScopeBracketDecorations(color: string) {
+        const red = parseInt(color.substr(1, 2), 16);
+        const green = parseInt(color.substr(3, 2), 16);
+        const blue = parseInt(color.substr(5, 2), 16);
+
         const decorationSettings: vscode.DecorationRenderOptions = {
             rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
         };
 
         this.activeBracketCSSElements.forEach((element) => {
-            decorationSettings[element[0]] = element[1].replace("{color}", color);
+            decorationSettings[element[0]] = element[1]
+                .replace("{color}", color)
+                .replace("{color-alpha}", `rgba(${red}, ${green}, ${blue}, ${this.highlightBracketBackgroundAlpha})`);
         });
 
         const decoration = vscode.window.createTextEditorDecorationType(decorationSettings);


### PR DESCRIPTION
I really enjoy this extension and wanted to add the capability to have an alpha channel background color to the highlighted brackets. This should do the trick and hopefully is in line with the rest of the project.