### PR TITLE
Lazily create manager to let other plugins be activated

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,14 @@
 import { commands, ExtensionContext, window, workspace, Event } from "vscode";
 import DocumentDecorationManager from "./documentDecorationManager";
-export function activate(context: ExtensionContext) {
+
+function wait(ms: number) {
+    return new Promise((resolve) => setTimeout(() => resolve(), ms));
+}
+
+export async function activate(context: ExtensionContext) {
+    // Below new() line calls huge require()s and takes about 2 secs in MBP 15-inch Mid 2014.
+    // Wait 0.5 sec to let other plugins be loaded before this plugin.
+    await wait(500);
     let documentDecorationManager = new DocumentDecorationManager();
 
     context.subscriptions.push(


### PR DESCRIPTION
`new DocumentDecorationManager()` calls `require()`s for prism.js, and it looks too huge to be loaded synchronously.

### Before

![image](https://user-images.githubusercontent.com/400558/45204904-9f893d00-b2bb-11e8-80b1-acf823e96b28.png)
See vscode.git, it took 1938ms to resolve `async activate()`. Seems to be loaded after BracketPair plugin.

### After
![image](https://user-images.githubusercontent.com/400558/45205315-c300b780-b2bc-11e8-9d63-b5872cdd7cf4.png)

Now vscode.git only took 83ms to resolve `async activate()`. 🐎 

### NOTE

If use `setTimeout(..., 0)`, other plugins wait BracketPair plugin. :cry:
![image](https://user-images.githubusercontent.com/400558/45205401-f80d0a00-b2bc-11e8-93c3-3d78796d41a6.png)