### PR TITLE
Add the extensionKind attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "engines": {
         "vscode": "^1.23.0"
     },
+    "extensionKind": [
+		"ui",
+		"workspace"
+	],
     "icon": "images/icon.png",
     "categories": [
         "Other"


### PR DESCRIPTION
As of VS Code 1.40 the extensionKind attribute in the package.json of the extension can be an array, pls see the [documentation](https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location).

In your current extension the old format `"extensionkind: "ui"` is used. We will be deprecating the string type for the extensionKind property in favour of string array type.