### PR TITLE
allow postcss syntax to be recognized as css 

### DIFF
--- a/src/documentDecorationManager.ts
+++ b/src/documentDecorationManager.ts
@@ -150,6 +150,7 @@ export default class DocumentDecorationManager {
             case "vb": return ["vbnet"];
             case "vue": return ["markup", "javascript"];
             case "xml": return ["markup"];
+            case "postcss" return ["css"];
             default: return [languageID];
         }
     }


### PR DESCRIPTION
As extension doesn't provide ability to setup mapping in settings json, here's my change to enable brackets highlight in postcss. Tested it here with some basic css:

https://user-images.githubusercontent.com/30532154/116292371-4a690500-a79e-11eb-95ec-f28d37520f68.mov

